### PR TITLE
Feature/change

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,12 +1,16 @@
 import {Controller, Post, Body} from '@nestjs/common';
 import {AuthService} from './auth.service';
 import {GoogleLoginDto} from './dto/google-login.dto';
+import {docs} from './auth.docs';
+import {ApiTags} from '@nestjs/swagger';
 
+@ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('google')
+  @docs.logInWithGoogle('구글 로그인')
   async logInWithGoogle(@Body() googleLoginDto: GoogleLoginDto) {
     return await this.authService.logInWithGoogle(googleLoginDto);
   }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -7,13 +7,12 @@ import {TypeOrmModule} from '@nestjs/typeorm';
 import {User} from './../user/entities/user.entity';
 import {JwtModule} from '@nestjs/jwt';
 import {JwtStrategy} from './strategy/jwt.strategy';
-import {Plant} from './../plant/entities/plant.entity';
 
 @Module({
   imports: [
     ConfigModule,
     PassportModule,
-    TypeOrmModule.forFeature([User, Plant]),
+    TypeOrmModule.forFeature([User]),
     JwtModule.registerAsync({
       inject: [ConfigService],
       useFactory: async (config: ConfigService) => {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,40 +1,56 @@
-import {Injectable} from '@nestjs/common';
+import {Injectable, BadRequestException, InternalServerErrorException} from '@nestjs/common';
 import {InjectRepository} from '@nestjs/typeorm';
 import {User} from './../user/entities/user.entity';
 import {Repository} from 'typeorm';
-import {GoogleLoginDto, GoogleLoginResponseDto} from './dto/google-login.dto';
+import {GoogleLoginDto} from './dto/google-login.dto';
 import {ConfigService} from '@nestjs/config';
 import {JwtService} from '@nestjs/jwt';
-import {Plant} from './../plant/entities/plant.entity';
+import {Err} from './../common/error';
 
 @Injectable()
 export class AuthService {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
-    @InjectRepository(Plant)
-    private readonly plantRepository: Repository<Plant>,
     private readonly configService: ConfigService,
     private readonly jwtService: JwtService,
   ) {}
 
   async logInWithGoogle(googleLoginDto: GoogleLoginDto): Promise<any> {
-    const oAuth2Client = this.configService.get('googleOAuth2Client');
+    try {
+      const oAuth2Client = this.configService.get('googleOAuth2Client');
 
-    const {tokens} = await oAuth2Client.getToken(googleLoginDto.authorizationCode);
-    const {email} = await oAuth2Client.getTokenInfo(tokens.access_token);
+      const {tokens} = await oAuth2Client.getToken(googleLoginDto.authorizationCode);
+      const {email} = await oAuth2Client.getTokenInfo(tokens.access_token);
+      let hasPlant = false;
+      let user = await this.userRepository.findOne({
+        where: {
+          gmail: email,
+        },
+        relations: ['plant'],
+      });
 
-    let user = await this.userRepository.findOne({
-      where: {
-        gmail: email,
-      },
-    });
+      // 새로운 유저인 경우 회원가입 진행
+      if (!user) {
+        user = await this.signUpWithGoogle(email, tokens.refresh_token);
+      }
 
-    if (!user) {
-      user = await this.signUpWithGoogle(email, tokens.refresh_token);
+      // 유저가 이미 식물 캐릭터를 가지고 있는지 확인
+      if (user.plant) {
+        hasPlant = true;
+      }
+
+      const accessToken = await this.createAccessToken(user.id);
+      return {accessToken, hasPlant};
+    } catch (error) {
+      switch (error.toString()) {
+        case 'Error: invalid_grant':
+          throw new BadRequestException(Err.CODE.INVALID_CODE);
+
+        default:
+          throw new InternalServerErrorException(Err.SERVER.UNEXPECTED_ERROR);
+      }
     }
-
-    return await this.createAccessToken(user.id);
   }
 
   async signUpWithGoogle(gmail: string, refreshToken: string): Promise<User> {
@@ -42,17 +58,12 @@ export class AuthService {
       gmail,
       googleRefreshToken: refreshToken,
     });
-    await this.plantRepository.save({
-      score: 0,
-      level: 1,
-      user,
-    });
     return user;
   }
 
-  async createAccessToken(id: number): Promise<GoogleLoginResponseDto> {
+  async createAccessToken(id: number): Promise<string> {
     const payload = {sub: id};
     const accessToken = this.jwtService.sign(payload);
-    return {accessToken};
+    return accessToken;
   }
 }

--- a/src/auth/dto/google-login.dto.ts
+++ b/src/auth/dto/google-login.dto.ts
@@ -1,6 +1,6 @@
 import {ApiProperty} from '@nestjs/swagger';
 import {IsString} from 'class-validator';
-import {BaseResponseDto} from 'src/common/dto/base-response.dto';
+import {BasePostReponseDto} from './../../common/dto/base-post-response.dto';
 
 export class GoogleLoginDto {
   @IsString()
@@ -16,10 +16,7 @@ export class GoogleLoginResponseDto {
   hasPlant: boolean;
 }
 
-export class GoogleLoginResponseBodyDto extends BaseResponseDto {
-  @ApiProperty({example: 201})
-  statusCode: number;
-
+export class GoogleLoginResponseBodyDto extends BasePostReponseDto {
   @ApiProperty()
   data: GoogleLoginResponseDto;
 }

--- a/src/auth/guard/jwt-auth.guard.ts
+++ b/src/auth/guard/jwt-auth.guard.ts
@@ -1,4 +1,4 @@
-import {Injectable, BadRequestException, ServiceUnavailableException} from '@nestjs/common';
+import {Injectable, InternalServerErrorException, UnauthorizedException} from '@nestjs/common';
 import {AuthGuard} from '@nestjs/passport';
 import {Err} from './../../common/error';
 
@@ -10,16 +10,16 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     }
     switch (info.toString()) {
       case 'Error: No auth token':
-        throw new BadRequestException(Err.TOKEN.NOT_SEND_TOKEN);
+        throw new UnauthorizedException(Err.TOKEN.NOT_SEND_TOKEN);
 
       case 'JsonWebTokenError: invalid signature':
-        throw new BadRequestException(Err.TOKEN.INVALID_TOKEN);
+        throw new UnauthorizedException(Err.TOKEN.INVALID_TOKEN);
 
       case 'TokenExpiredError: jwt expired':
-        throw new BadRequestException(Err.TOKEN.JWT_EXPIRED);
+        throw new UnauthorizedException(Err.TOKEN.JWT_EXPIRED);
 
       default:
-        throw new ServiceUnavailableException(Err.SERVER.UNEXPECTED_ERROR);
+        throw new InternalServerErrorException(Err.SERVER.UNEXPECTED_ERROR);
     }
   }
 }

--- a/src/common/dto/base-get-response.dto.ts
+++ b/src/common/dto/base-get-response.dto.ts
@@ -1,0 +1,9 @@
+import {ApiProperty} from '@nestjs/swagger';
+
+export class BaseGetReponseDto {
+  @ApiProperty({example: '200'})
+  code: number;
+
+  @ApiProperty({example: ''})
+  message: string;
+}

--- a/src/common/dto/base-post-response.dto.ts
+++ b/src/common/dto/base-post-response.dto.ts
@@ -1,0 +1,9 @@
+import {ApiProperty} from '@nestjs/swagger';
+
+export class BasePostReponseDto {
+  @ApiProperty({example: '201'})
+  code: number;
+
+  @ApiProperty({example: ''})
+  message: string;
+}

--- a/src/common/dto/base-response.dto.ts
+++ b/src/common/dto/base-response.dto.ts
@@ -1,6 +1,0 @@
-import {ApiProperty} from '@nestjs/swagger';
-
-export class BaseResponseDto {
-  @ApiProperty({example: 'true'})
-  success: boolean;
-}

--- a/src/common/dto/base-update-response.dto.ts
+++ b/src/common/dto/base-update-response.dto.ts
@@ -1,10 +1,7 @@
 import {ApiProperty} from '@nestjs/swagger';
-import {BaseResponseDto} from 'src/common/dto/base-response.dto';
+import {BaseGetReponseDto} from './base-get-response.dto';
 
-export class BaseUpdateResponseDto extends BaseResponseDto {
-  @ApiProperty({example: 200})
-  statusCode: number;
-
+export class BaseUpdateResponseDto extends BaseGetReponseDto {
   @ApiProperty({example: '업데이트에 성공하였습니다.'})
   data;
 }

--- a/src/common/entity/base-entity.entity.ts
+++ b/src/common/entity/base-entity.entity.ts
@@ -13,12 +13,12 @@ export class BaseEntity {
 
   /* Date Columns */
 
-  @CreateDateColumn()
+  @CreateDateColumn({select: false})
   createdAt: Date;
 
-  @UpdateDateColumn()
+  @UpdateDateColumn({select: false})
   updatedAt: Date;
 
-  @DeleteDateColumn()
+  @DeleteDateColumn({select: false})
   deletedAt: Date | null;
 }

--- a/src/common/exception/httpException.filter.ts
+++ b/src/common/exception/httpException.filter.ts
@@ -12,11 +12,11 @@ export class HttpExceptionFilter implements ExceptionFilter {
       | {error: string; message: string[]; code: number | null};
     if (err.code) {
       return response.status(status).json({
-        success: false,
-        statusCode: err.code,
-        data: err.message,
+        code: err.code,
+        message: err.message,
+        data: '',
       });
     }
-    response.status(status).json({success: false, statusCode: status, data: err.message});
+    response.status(status).json({code: status, message: err.message, data: ''});
   }
 }

--- a/src/common/interceptor/transform.interceptor.ts
+++ b/src/common/interceptor/transform.interceptor.ts
@@ -3,7 +3,7 @@ import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 
 export interface Response<T> {
-  statusCode: number;
+  code: number;
   data: T;
 }
 
@@ -12,8 +12,8 @@ export class TransformInterceptor<T> implements NestInterceptor<T, Response<T>> 
   intercept(context: ExecutionContext, next: CallHandler): Observable<Response<T>> {
     return next.handle().pipe(
       map(data => ({
-        success: true,
-        statusCode: context.switchToHttp().getResponse().statusCode,
+        code: context.switchToHttp().getResponse().statusCode,
+        message: '',
         data,
       })),
     );

--- a/src/mail/dto/getMailNumber.dto.ts
+++ b/src/mail/dto/getMailNumber.dto.ts
@@ -1,15 +1,12 @@
 import {ApiProperty} from '@nestjs/swagger';
-import {BaseResponseDto} from 'src/common/dto/base-response.dto';
+import {BaseGetReponseDto} from './../../common/dto/base-get-response.dto';
 
 export class GetMailNumberResponseDto {
   @ApiProperty({description: '이메일의 개수 총합', example: '1'})
   totalCount: number;
 }
 
-export class GetMailNumberResponseBodyDto extends BaseResponseDto {
-  @ApiProperty({example: 200})
-  statusCode: number;
-
+export class GetMailNumberResponseBodyDto extends BaseGetReponseDto {
   @ApiProperty()
   data: GetMailNumberResponseDto;
 }

--- a/src/mail/entities/mail.entity.ts
+++ b/src/mail/entities/mail.entity.ts
@@ -6,8 +6,7 @@ import {User} from './../../user/entities/user.entity';
 @Entity()
 export class Mail extends BaseEntity {
   @Column()
-  @ApiProperty({description: '사용자의 이메일 개수 총합', example: 'test@test.com'})
-  totalNumber: number;
+  totalCount: number;
 
   /* Relations */
   @OneToOne(() => User, user => user.mail)

--- a/src/mail/mail.controller.ts
+++ b/src/mail/mail.controller.ts
@@ -2,14 +2,18 @@ import {Controller, Get, UseGuards} from '@nestjs/common';
 import {MailService} from './mail.service';
 import {JwtAuthGuard} from './../auth/guard/jwt-auth.guard';
 import {AuthUser} from './../common/decorator/user.decorator';
+import {ApiTags} from '@nestjs/swagger';
+import {docs} from './mail.docs';
 
+@ApiTags('mail')
 @Controller('mail')
 export class MailController {
   constructor(private readonly mailService: MailService) {}
 
-  @Get('labels')
+  @Get('count')
+  @docs.getMailTotalCount('사용자 메일 개수')
   @UseGuards(JwtAuthGuard)
-  getMailNumber(@AuthUser() user) {
-    return this.mailService.getMailNumber(user.id);
+  getMailTotalCount(@AuthUser() user) {
+    return this.mailService.getMailTotalCount(user.id);
   }
 }

--- a/src/plant/dto/createPlant.dto.ts
+++ b/src/plant/dto/createPlant.dto.ts
@@ -1,6 +1,6 @@
 import {ApiProperty} from '@nestjs/swagger';
-import {BaseResponseDto} from 'src/common/dto/base-response.dto';
 import {GetPlantInfoResponseDto} from './getPlantInfo.dto';
+import {BasePostReponseDto} from './../../common/dto/base-post-response.dto';
 
 export class CreatePlantDto {
   @ApiProperty({description: '식물의 이름', example: '식물이'})
@@ -10,10 +10,7 @@ export class CreatePlantDto {
   kind: string;
 }
 
-export class CreatePlantResponseBodyDto extends BaseResponseDto {
-  @ApiProperty({example: 201})
-  statusCode: number;
-
+export class CreatePlantResponseBodyDto extends BasePostReponseDto {
   @ApiProperty()
   data: GetPlantInfoResponseDto;
 }

--- a/src/plant/dto/getPlantInfo.dto.ts
+++ b/src/plant/dto/getPlantInfo.dto.ts
@@ -1,5 +1,5 @@
 import {ApiProperty} from '@nestjs/swagger';
-import {BaseResponseDto} from 'src/common/dto/base-response.dto';
+import {BaseGetReponseDto} from './../../common/dto/base-get-response.dto';
 
 export class GetPlantInfoResponseDto {
   @ApiProperty({description: '식물의 아이디', example: '1'})
@@ -21,10 +21,7 @@ export class GetPlantInfoResponseDto {
   ordinalNumber: number;
 }
 
-export class GetPlantInfoResponseBodyDto extends BaseResponseDto {
-  @ApiProperty({example: 200})
-  statusCode: number;
-
+export class GetPlantInfoResponseBodyDto extends BaseGetReponseDto {
   @ApiProperty()
   data: GetPlantInfoResponseDto;
 }

--- a/src/plant/entities/plant.entity.ts
+++ b/src/plant/entities/plant.entity.ts
@@ -6,12 +6,19 @@ import {User} from './../../user/entities/user.entity';
 @Entity()
 export class Plant extends BaseEntity {
   @Column()
-  @ApiProperty({description: '식물의 점수', example: '20'})
+  name: string;
+
+  @Column()
+  kind: string;
+
+  @Column()
   score: number;
 
   @Column()
-  @ApiProperty({description: '식물의 레벨', example: '2'})
   level: number;
+
+  @Column()
+  ordinalNumber: number;
 
   /* Relations */
   @OneToOne(() => User, user => user.plant)

--- a/src/plant/plant.controller.ts
+++ b/src/plant/plant.controller.ts
@@ -1,15 +1,41 @@
-import {Controller, Get, UseGuards} from '@nestjs/common';
+import {Controller, Get, UseGuards, Post, Body, Patch} from '@nestjs/common';
 import {PlantService} from './plant.service';
 import {JwtAuthGuard} from './../auth/guard/jwt-auth.guard';
 import {AuthUser} from './../common/decorator/user.decorator';
+import {ApiTags} from '@nestjs/swagger';
+import {docs} from './plant.docs';
+import {CreatePlantDto} from './dto/createPlant.dto';
 
+@ApiTags('plant')
 @Controller('plant')
 export class PlantController {
   constructor(private readonly plantService: PlantService) {}
 
+  @Post('me')
+  @docs.createPlant('사용자 식물 생성')
+  @UseGuards(JwtAuthGuard)
+  createPlant(@AuthUser() user, @Body() createPlant: CreatePlantDto) {
+    return this.plantService.createPlant(user.id, createPlant);
+  }
+
   @Get('me')
+  @docs.getPlantInfo('사용자 식물 정보')
   @UseGuards(JwtAuthGuard)
   getPlantInfo(@AuthUser() user) {
     return this.plantService.getPlantInfo(user.id);
+  }
+
+  @Patch('me')
+  @docs.updatePlantInfo('사용자 식물 정보 업데이트')
+  @UseGuards(JwtAuthGuard)
+  updatePlantInfo(@AuthUser() user, @Body() createPlant: CreatePlantDto) {
+    return this.plantService.updatePlantInfo(user.id, createPlant);
+  }
+
+  @Post('reset')
+  @docs.resetPlant('사용자 식물 레벨 / 점수 초기화')
+  @UseGuards(JwtAuthGuard)
+  resetPlant(@AuthUser() user, @Body() createPlant: CreatePlantDto) {
+    return this.plantService.resetPlant(user.id, createPlant);
   }
 }

--- a/src/plant/plant.service.ts
+++ b/src/plant/plant.service.ts
@@ -1,8 +1,10 @@
-import {Injectable} from '@nestjs/common';
+import {Injectable, BadRequestException} from '@nestjs/common';
 import {InjectRepository} from '@nestjs/typeorm';
 import {Plant} from './entities/plant.entity';
 import {Repository} from 'typeorm';
 import {User} from './../user/entities/user.entity';
+import {Err} from './../common/error';
+import {CreatePlantDto} from './dto/createPlant.dto';
 
 @Injectable()
 export class PlantService {
@@ -13,25 +15,98 @@ export class PlantService {
     private readonly userRepository: Repository<User>,
   ) {}
 
-  async updatePlantInfo(plantId: number, score: number) {
-    const plant = await this.plantRepository.findOne(plantId);
-    let level = plant.level;
-
-    // todo  레벨 계산하는 로직 추가
-
-    if (score > 0) {
-      level = 1;
-      await this.plantRepository.update(plantId, {score, level});
-    }
-  }
-
-  async getPlantInfo(userId: number) {
+  async createPlant(userId: number, createPlantDto: CreatePlantDto) {
     const user = await this.userRepository.findOne({
       where: {
         id: userId,
       },
       relations: ['plant'],
     });
+
+    if (!user) throw new BadRequestException(Err.USER.NOT_FOUND);
+    if (user.plant) throw new BadRequestException(Err.PLANT.EXISTING_PlANT);
+
+    const plant = await this.plantRepository.save({
+      name: createPlantDto.name,
+      kind: createPlantDto.kind,
+      score: 0,
+      level: 1,
+      user,
+      ordinalNumber: 0,
+    });
+    delete plant.user;
+    delete plant.createdAt;
+    delete plant.updatedAt;
+    delete plant.deletedAt;
+    return plant;
+  }
+
+  async getPlantInfo(userId: number): Promise<Plant> {
+    const user = await this.userRepository.findOne({
+      where: {
+        id: userId,
+      },
+      relations: ['plant'],
+    });
+
+    if (!user) throw new BadRequestException(Err.USER.NOT_FOUND);
+    if (!user.plant) throw new BadRequestException(Err.PLANT.NOT_FOUND);
+
     return await this.plantRepository.findOne(user.plant.id);
+  }
+
+  async updatePlantInfo(userId: number, createPlantDto: CreatePlantDto) {
+    const user = await this.userRepository.findOne({
+      where: {
+        id: userId,
+      },
+      relations: ['plant'],
+    });
+
+    if (!user) throw new BadRequestException(Err.USER.NOT_FOUND);
+    if (!user.plant) throw new BadRequestException(Err.PLANT.NOT_FOUND);
+
+    await this.plantRepository.update(user.plant.id, createPlantDto);
+    return '업데이트에 성공하였습니다.';
+  }
+
+  async updatePlantScore(plantId: number, score: number) {
+    const plant = await this.plantRepository.findOne(plantId);
+    const level = plant.level;
+
+    // todo  레벨 계산하는 로직 추가
+    const sum = plant.score + score;
+
+    await this.plantRepository.update(plantId, {
+      score: sum,
+      level,
+    });
+  }
+
+  async resetPlant(userId: number, createPlantDto: CreatePlantDto) {
+    const user = await this.userRepository.findOne({
+      where: {
+        id: userId,
+      },
+      relations: ['plant'],
+    });
+
+    if (!user) throw new BadRequestException(Err.USER.NOT_FOUND);
+    if (!user.plant) throw new BadRequestException(Err.PLANT.NOT_FOUND);
+
+    await this.plantRepository.update(user.plant.id, {
+      name: createPlantDto.name,
+      kind: createPlantDto.kind,
+      score: 0,
+      level: 1,
+      ordinalNumber: user.plant.ordinalNumber + 1,
+    });
+
+    const plant = await this.plantRepository.findOne(user.plant.id);
+    delete plant.user;
+    delete plant.createdAt;
+    delete plant.updatedAt;
+    delete plant.deletedAt;
+    return plant;
   }
 }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -18,7 +18,7 @@ export class User extends BaseEntity {
     unique: true,
     nullable: true,
   })
-  @ApiProperty({description: '사용자의 푸시 알림 받고 싶은 메일 개수', example: 'true'})
+  @ApiProperty({description: '사용자의 메일 삭제 알림 개수 ', example: 'true'})
   notificationLimit: boolean;
 
   @Column({

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,21 +1,12 @@
 import {Controller, Get, Post, Body, Patch, Param, Delete} from '@nestjs/common';
 import {UserService} from './user.service';
-import {CreateUserDto} from './dto/create-user.dto';
 import {UpdateUserDto} from './dto/update-user.dto';
+import {ApiTags} from '@nestjs/swagger';
 
+@ApiTags('user')
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
-
-  @Post()
-  create(@Body() createUserDto: CreateUserDto) {
-    return this.userService.create(createUserDto);
-  }
-
-  @Get()
-  findAll() {
-    return this.userService.findAll();
-  }
 
   @Get(':id')
   findOne(@Param('id') id: string) {


### PR DESCRIPTION
## 변경사항

### 이슈 해결
- 구글 로그인은 완료한 상태인데, 캐릭터 설정 후 회원가입 완료 버튼을 누르지 않고 앱을 종료한 경우 → 다시 앱을 실행시켰을 때 구글 로그인(앱 첫 화면)부터 진행하도록 구현
- 식물 설정하기 전에 종료한 경우: hasPlant: false
- 이미 식물이 있는 경우: hasPlant: true

### 사용자 식물 초기화 API
#### api/v1/plant/reset
- 사용자가 식물을 다 키운 경우, 다시 키우고 싶을 때 사용합니다.
- ordinalNumber(사용자가 지금까지 키운 식물의 수)

### response 스타일 통일
```
{
  "code": 401,
  "message": "유효하지 않은 인가코드입니다.",
  "data": ""
}

{
  "code": 201,
  "message": "",
  "data": {
    "accessToken": "123456789"
  }
}
```