### PR TITLE
Feature/plant history

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AH HA
 
 ## 📚 ERD
-![image](https://user-images.githubusercontent.com/66551410/151686763-0659cdc5-8bcf-454e-8d02-fb6b31d2f767.png)
+![image](https://user-images.githubusercontent.com/66551410/151972459-5b975570-138a-4cc8-8437-7cbdd1a0de4c.png)
 
 ## 📦 CICD Architecture
 ![image](https://user-images.githubusercontent.com/66551410/143553684-ec4748e5-d4ba-4c63-ba80-b7c958e00eed.png)

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import authConfig from './common/config/auth.config';
 import googleOAuth2ClientConfig from './common/config/googleOAuth2Client.config';
 import {ScheduleModule} from '@nestjs/schedule';
 import {PushNotificationModule} from './push-notification/push-notification.module';
+import {PlantHistoryModule} from './plant-history/plant-history.module';
 import googleAuthConfig from './common/config/googleAuth.config';
 import googlePubSubConfig from './common/config/googlePubSub.config';
 import awsConfig from './common/config/dynamoDB.config';
@@ -40,6 +41,7 @@ import dynamoDBConfig from './common/config/dynamoDB.config';
     MailModule,
     ScheduleModule.forRoot(),
     PushNotificationModule,
+    PlantHistoryModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/plant-history/dto/findAllHistoryList.dto.ts
+++ b/src/plant-history/dto/findAllHistoryList.dto.ts
@@ -1,0 +1,24 @@
+import {ApiProperty} from '@nestjs/swagger';
+import {BaseGetReponseDto} from '../../common/dto/base-get-response.dto';
+
+export class findAllHistoryList {
+  @ApiProperty({description: '식물의 아이디', example: '1'})
+  id: number;
+
+  @ApiProperty({description: '식물의 이름', example: '식물이'})
+  name: string;
+
+  @ApiProperty({description: '식물의 종류', example: 'apple'})
+  kind: string;
+
+  @ApiProperty({description: '식물의 키우기 시작한 시간', example: '2022-02-01T12:07:05.000Z'})
+  startTime: number;
+
+  @ApiProperty({description: '식물의 키우시 종료한 시간', example: '2022-02-01T12:07:05.000Z'})
+  finishTime: number;
+}
+
+export class findAllHistoryListResponseBodyDto extends BaseGetReponseDto {
+  @ApiProperty({type: [findAllHistoryList]})
+  data: findAllHistoryList[];
+}

--- a/src/plant-history/entities/plant-history.entity.ts
+++ b/src/plant-history/entities/plant-history.entity.ts
@@ -1,0 +1,22 @@
+import {Column, Entity, ManyToOne} from 'typeorm';
+import {BaseEntity} from './../../common/entity/base-entity.entity';
+import {User} from './../../user/entities/user.entity';
+
+@Entity()
+export class PlantHistory extends BaseEntity {
+  @Column({nullable: true})
+  name: string;
+
+  @Column({nullable: true})
+  kind: string;
+
+  @Column()
+  startTime: Date;
+
+  @Column({nullable: true})
+  finishTime: Date;
+
+  /* Relations */
+  @ManyToOne(() => User, user => user.plantHistoryList, {onDelete: 'CASCADE'})
+  user: User;
+}

--- a/src/plant-history/plant-history.controller.spec.ts
+++ b/src/plant-history/plant-history.controller.spec.ts
@@ -1,0 +1,20 @@
+import {Test, TestingModule} from '@nestjs/testing';
+import {PlantHistoryController} from './plant-history.controller';
+import {PlantHistoryService} from './plant-history.service';
+
+describe('PlantHistoryController', () => {
+  let controller: PlantHistoryController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PlantHistoryController],
+      providers: [PlantHistoryService],
+    }).compile();
+
+    controller = module.get<PlantHistoryController>(PlantHistoryController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/plant-history/plant-history.controller.ts
+++ b/src/plant-history/plant-history.controller.ts
@@ -1,0 +1,19 @@
+import {Controller, Get, UseGuards} from '@nestjs/common';
+import {PlantHistoryService} from './plant-history.service';
+import {JwtAuthGuard} from './../auth/guard/jwt-auth.guard';
+import {AuthUser} from './../common/decorator/user.decorator';
+import {docs} from './plant-history.docs';
+import {ApiTags} from '@nestjs/swagger';
+
+@ApiTags('plant-history')
+@Controller('plant-history')
+export class PlantHistoryController {
+  constructor(private readonly plantHistoryService: PlantHistoryService) {}
+
+  @Get()
+  @docs.findAllHistory('사용자 식물 히스토리 정보')
+  @UseGuards(JwtAuthGuard)
+  findAllHistory(@AuthUser() user) {
+    return this.plantHistoryService.findAllHistory(user.id);
+  }
+}

--- a/src/plant-history/plant-history.docs.ts
+++ b/src/plant-history/plant-history.docs.ts
@@ -1,0 +1,34 @@
+import {applyDecorators} from '@nestjs/common';
+import {ApiOperation, ApiResponse, ApiBearerAuth, ApiOkResponse} from '@nestjs/swagger';
+import {SwaggerMethodDoc} from 'src/common/types';
+import {findAllHistoryListResponseBodyDto} from './dto/findAllHistoryList.dto';
+import {PlantHistoryController} from './plant-history.controller';
+
+export const docs: SwaggerMethodDoc<PlantHistoryController> = {
+  findAllHistory(summary: string) {
+    return applyDecorators(
+      ApiBearerAuth(),
+      ApiOperation({
+        summary,
+        description:
+          '사용자의 식물 히스토리 정보를 반환합니다. 순서는 오래된 정보부터 최신 정보 순으로 정렬하여 반환합니다.',
+      }),
+      ApiOkResponse({
+        type: findAllHistoryListResponseBodyDto,
+      }),
+      ApiResponse({
+        status: 400,
+        description: '1. 존재하지 않는 사용자입니다.',
+      }),
+      ApiResponse({
+        status: 401,
+        description:
+          '1. 토큰이 전송되지 않았습니다. \t\n 2. 유효하지 않은 토큰입니다. \t\n 3. 토큰이 만료되었습니다.',
+      }),
+      ApiResponse({
+        status: 500,
+        description: '서버에러가 발생했습니다.',
+      }),
+    );
+  },
+};

--- a/src/plant-history/plant-history.module.ts
+++ b/src/plant-history/plant-history.module.ts
@@ -1,0 +1,13 @@
+import {Module} from '@nestjs/common';
+import {PlantHistoryService} from './plant-history.service';
+import {PlantHistoryController} from './plant-history.controller';
+import {TypeOrmModule} from '@nestjs/typeorm';
+import {User} from 'src/user/entities/user.entity';
+import {PlantHistory} from './entities/plant-history.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User, PlantHistory])],
+  controllers: [PlantHistoryController],
+  providers: [PlantHistoryService],
+})
+export class PlantHistoryModule {}

--- a/src/plant-history/plant-history.service.spec.ts
+++ b/src/plant-history/plant-history.service.spec.ts
@@ -1,0 +1,18 @@
+import {Test, TestingModule} from '@nestjs/testing';
+import {PlantHistoryService} from './plant-history.service';
+
+describe('PlantHistoryService', () => {
+  let service: PlantHistoryService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PlantHistoryService],
+    }).compile();
+
+    service = module.get<PlantHistoryService>(PlantHistoryService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/plant-history/plant-history.service.ts
+++ b/src/plant-history/plant-history.service.ts
@@ -1,0 +1,50 @@
+import {Injectable, BadRequestException} from '@nestjs/common';
+import {InjectRepository} from '@nestjs/typeorm';
+import {PlantHistory} from './entities/plant-history.entity';
+import {Repository} from 'typeorm';
+import {User} from '../user/entities/user.entity';
+import {Err} from './../common/error';
+
+@Injectable()
+export class PlantHistoryService {
+  constructor(
+    @InjectRepository(PlantHistory)
+    private readonly plantHistoryRepository: Repository<PlantHistory>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  create() {
+    return 'This action adds a new plantHistory';
+  }
+
+  async findAllHistory(userId: number) {
+    const user = await this.userRepository.findOne({
+      where: {
+        id: userId,
+      },
+      relations: ['plant'],
+    });
+
+    if (!user) throw new BadRequestException(Err.USER.NOT_FOUND);
+
+    const plantHistoryList = await this.plantHistoryRepository.find({
+      where: {
+        user,
+      },
+      order: {
+        createdAt: 'ASC',
+      },
+    });
+    plantHistoryList.pop();
+    return plantHistoryList;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} plantHistory`;
+  }
+
+  update(id: number) {
+    return `This action updates a #${id} plantHistory`;
+  }
+}

--- a/src/plant/entities/plant.entity.ts
+++ b/src/plant/entities/plant.entity.ts
@@ -1,5 +1,4 @@
 import {Column, Entity, OneToOne} from 'typeorm';
-import {ApiProperty} from '@nestjs/swagger';
 import {BaseEntity} from './../../common/entity/base-entity.entity';
 import {User} from './../../user/entities/user.entity';
 

--- a/src/plant/plant.docs.ts
+++ b/src/plant/plant.docs.ts
@@ -18,7 +18,8 @@ export const docs: SwaggerMethodDoc<PlantController> = {
       ApiBearerAuth(),
       ApiOperation({
         summary,
-        description: '사용자의 식물을 생성합니다.',
+        description:
+          '사용자의 식물을 생성합니다. 초기 설정 값은 socre: 0, level: 1, ordinalNumber: 0 입니다.',
       }),
       ApiCreatedResponse({
         type: CreatePlantResponseBodyDto,
@@ -94,7 +95,7 @@ export const docs: SwaggerMethodDoc<PlantController> = {
       ApiOperation({
         summary,
         description:
-          '사용자가 식물이 성장 완료한 경우, 다시 기르기 위해 사용합니다. \t\n 사용자의 식물의 level, score를 초기화합니다. 사용자가 기른 식물수(ordinalNumber)가 1 증가 합니다.',
+          '사용자가 식물이 성장 완료한 경우, 다시 기르기 위해 사용합니다. name, kind는 새로 키우기 시작한 식물의 정보입니다. \t\n 사용자의 식물의 level, score를 초기화합니다. 사용자가 기른 식물수(ordinalNumber)가 1 증가 합니다.',
       }),
       ApiCreatedResponse({
         type: CreatePlantResponseBodyDto,

--- a/src/plant/plant.module.ts
+++ b/src/plant/plant.module.ts
@@ -4,9 +4,10 @@ import {PlantController} from './plant.controller';
 import {TypeOrmModule} from '@nestjs/typeorm';
 import {Plant} from './entities/plant.entity';
 import {User} from './../user/entities/user.entity';
+import {PlantHistory} from './../plant-history/entities/plant-history.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Plant])],
+  imports: [TypeOrmModule.forFeature([User, Plant, PlantHistory])],
   controllers: [PlantController],
   providers: [PlantService],
   exports: [PlantService],

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,12 +1,13 @@
-import {Column, Entity, JoinColumn, OneToOne} from 'typeorm';
+import {Column, Entity, JoinColumn, OneToOne, OneToMany} from 'typeorm';
 import {ApiProperty} from '@nestjs/swagger';
 import {BaseEntity} from './../../common/entity/base-entity.entity';
 import {Plant} from './../../plant/entities/plant.entity';
 import {Mail} from './../../mail/entities/mail.entity';
+import {PlantHistory} from './../../plant-history/entities/plant-history.entity';
 
 export enum GetNotification {
-  YES = 'YES', // 한국어 자막
-  NO = 'NO', // 영어 자막
+  YES = 'YES', // 환경 보호 알림 동의
+  NO = 'NO', // 환경 보호 알림 해제
 }
 
 @Entity()
@@ -39,6 +40,9 @@ export class User extends BaseEntity {
   @OneToOne(() => Plant, plant => plant.user, {eager: true, onDelete: 'CASCADE'})
   @JoinColumn()
   plant: Plant;
+
+  @OneToMany(() => PlantHistory, plantHistory => plantHistory.user)
+  plantHistoryList: PlantHistory[];
 
   @OneToOne(() => Mail, mail => mail.user, {eager: true, onDelete: 'CASCADE'})
   @JoinColumn()


### PR DESCRIPTION
## 변경사항

### plant history entity 추가
- 연관관계 설정하였습니다.
  - user : plantHIstory = 1 : N
### plant history 라우터 추가
**GET api/v1/plant-history**
- 사용자의 식물 히스토리 정보 반환하는 라우터입니다.
- 라우터가 추가되어서 plant 생성 및 초기화 라우터가 동작하는 과정에 plant history도 생성 및 업데이트하는 로직이 추가되었습니다.

## TODO
- plant service에 plant history repository 사용하는 부분을 plant history service에서 구현하고, 주입받아서 사용
- deviceId로 푸시알림 테스트
- 공통되는 로직 util로 따로 만들기
  - googleRefreshToken으로 googleAccessToken받아서 credential 설정하는 부분
  - google mail setting 하는 부분
 - sentry 설정해서 bug tracking