### PR TITLE
Feature/plant score

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -34,7 +34,10 @@ export class AuthService {
       if (!user) {
         user = await this.signUpWithGoogle(email, tokens.refresh_token, googleLoginDto.deviceId);
       } else {
-        await this.userRepository.update(user.id, {deviceId: googleLoginDto.deviceId});
+        await this.userRepository.update(user.id, {
+          deviceId: googleLoginDto.deviceId,
+          googleRefreshToken: tokens.refresh_token,
+        });
       }
 
       // 유저가 이미 식물 캐릭터를 가지고 있는지 확인

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -56,6 +56,7 @@ export class MailService {
     if (!user.mail) {
       await this.mailRepository.save({totalCount, user});
     } else {
+      // 전에 있었던 메일 개수 보다 현재 메일 개수가 적은 경우 (사용자가 메일을 삭제한 경우)
       const score = user.mail.totalCount - totalCount;
       if (score > 0) await this.plantService.updatePlantScore(user.plant.id, score);
       await this.mailRepository.update(user.mail.id, {totalCount});

--- a/src/plant/plant.docs.ts
+++ b/src/plant/plant.docs.ts
@@ -45,7 +45,7 @@ export const docs: SwaggerMethodDoc<PlantController> = {
       ApiOperation({
         summary,
         description:
-          '사용자의 식물 정보를 반환합니다. \t\n 식물 종류는 GREENONION : 대파, TOMATO : 토마토, BROCCOLI : 브로콜리 입니다.',
+          '사용자의 식물 정보를 반환합니다. \t\n 식물 종류는 GREENONION : 대파, TOMATO : 토마토, BROCCOLI : 브로콜리 입니다. \t\n 레벨과 점수에 대한 정보는 다음과 같습니다. \t\n level 1 : 0 - 19 \t\n level 2 : 20 - 39 \t\n level 3 : 40 - 59 \t\n level 4 : 60 - 79 \t\n level 5 : 80 - 100 \t\n 식물 점수가 100 이상인 경우, 레벨 및 점수 갱신은 일어나지 않습니다.',
       }),
       ApiOkResponse({
         type: GetPlantInfoResponseBodyDto,

--- a/src/plant/plant.service.ts
+++ b/src/plant/plant.service.ts
@@ -5,7 +5,6 @@ import {Repository} from 'typeorm';
 import {User} from './../user/entities/user.entity';
 import {Err} from './../common/error';
 import {CreatePlantDto} from './dto/createPlant.dto';
-import {PlantHistory} from './../plant-history/entities/plant-history.entity';
 import {PlantHistoryService} from './../plant-history/plant-history.service';
 import {UpdatePlantInfoDto} from './dto/updatePlantInfo.dto';
 

--- a/src/plant/plant.service.ts
+++ b/src/plant/plant.service.ts
@@ -78,10 +78,17 @@ export class PlantService {
 
   async updatePlantScore(plantId: number, score: number) {
     const plant = await this.plantRepository.findOne(plantId);
-    const level = plant.level;
+    let level = plant.level;
 
-    // todo  레벨 계산하는 로직 추가
-    const sum = plant.score + score;
+    let sum = plant.score + score;
+
+    level = Math.floor(sum / 20) + 1;
+
+    // 점수가 최고 정수에 도달한 경우
+    if (sum > 100) {
+      sum = 100;
+      level = 5;
+    }
 
     await this.plantRepository.update(plantId, {
       score: sum,

--- a/src/push-notification/push-notification.service.ts
+++ b/src/push-notification/push-notification.service.ts
@@ -1,6 +1,5 @@
 import {Injectable, OnApplicationBootstrap} from '@nestjs/common';
 import {Cron, SchedulerRegistry} from '@nestjs/schedule';
-import {CronJob} from 'cron';
 import * as admin from 'firebase-admin';
 import {ConfigService} from '@nestjs/config';
 import {PubSub} from '@google-cloud/pubsub';

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,5 +1,4 @@
 import {Column, Entity, JoinColumn, OneToOne, OneToMany} from 'typeorm';
-import {ApiProperty} from '@nestjs/swagger';
 import {BaseEntity} from './../../common/entity/base-entity.entity';
 import {Plant} from './../../plant/entities/plant.entity';
 import {Mail} from './../../mail/entities/mail.entity';


### PR DESCRIPTION
## 변경사항

### 구글 로그인 API 호출시 기존 사용자의 구글 refresh token도 업데이트 하도록 변경
- 구글 refresh token의 유효기간을 고려하여 업데이트 하도록 로직을 추가했습니다.
- [ ] 메일 API 호출 시에, refresh token 확인하고 자동으로 업데이트 하도록 변경

### 식물 점수 계산 로직 추가
- 안드팀과 합의한 내용을 적용하였습니다.
```
level 1 : 0 - 19
level 2 : 20 - 39
level 3 : 40 - 59
level 4 : 60 - 79
level 5 : 80 - 100
```
- score가 100 인경우는, 사용자가 메일을 삭제해서 점수가 늘어나는 경우에도 level : 5, score : 100으로 점수를 유지합니다.